### PR TITLE
Fix BLiP's Help Center url

### DIFF
--- a/configs/blip.json
+++ b/configs/blip.json
@@ -2,16 +2,16 @@
   "index_name": "blip",
   "start_urls": [
     {
-      "url": "https://hmg-help.blip.ai/docs/",
+      "url": "https://help.blip.ai/docs/",
       "tags": [
         "docs"
       ],
       "selectors_key": "docs"
     },
-    "https://hmg-help.blip.ai/"
+    "https://help.blip.ai/"
   ],
   "sitemap_urls": [
-    "https://hmg-help.blip.ai/sitemap.xml"
+    "https://help.blip.ai/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation(s)

I have just changed the BLiP's url. The Help Center moved to another url.

### What is the current behaviour?

NA

### What is the expected behaviour?

Now, Docsearch can index content in a correct site.

##### NB: Do you want to request a **feature** or report a **bug**?

NA

##### NB2: Any other feedback / questions ?

NA